### PR TITLE
Refactor rules-message and purge-reaction fetching

### DIFF
--- a/public-ideas-to-trello.py
+++ b/public-ideas-to-trello.py
@@ -1,6 +1,9 @@
+import asyncio
 import json
 import trello
 import os
+import discord
+import traceback
 from discord.ext.commands import Bot
 from datetime import datetime, timedelta
 
@@ -9,8 +12,14 @@ config = {
     'trello_api_key': "Put Trello API key here",
     'trello_list_id': "Put the ID of the Trello list that new cards should be created in here",
     'discord_channel_id': "Put the ID of the Discord channel you want to get public ideas from here",
-    'discord_reactions_message': "Put the ID of the message with all the reactions you want to purge here",
-    'rule_reminder_message': 'Put the ID of the message you want to be sent to remind people of the rules here',
+    'discord_reactions_message': [
+        "Put the channel ID of the message with all the reactions you want to purge here",
+        "Put the ID of the message with all the reactions you want to purge here"
+    ],
+    'rule_reminder_message': [
+        'Put the channel ID of the message you want to be sent to remind people of the rules here',
+        'Put the ID of the message you want to be sent to remind people of the rules here'
+    ],
     'trello_api_secret': "Put your Trello secret here",
     'trello_token': "Insert your Trello token here"
 }
@@ -25,6 +34,9 @@ with open('config.json', 'w') as f:
     json.dump(config, f, indent='\t')
 
 bot = Bot(command_prefix='t!')
+bot.rules_message = None
+bot.purge_reactions = None
+
 trellobot = trello.TrelloClient(
     api_key=config['trello_api_key'],
     api_secret=config['trello_api_secret'],
@@ -37,13 +49,23 @@ async def description_reminder(ctx):
     async for message in ctx.channel.history(limit=20):
         authors.append(message.author)
     if bot.user not in authors:
-        what_to_send = await ctx.channel.get_message(id=config['rule_reminder_message'])
-        await ctx.channel.send(what_to_send.content)
+        await ctx.channel.send(bot.rules_message)
 
 
 @bot.event
 async def on_ready():
-    print("Ready!")
+    try:
+        rule_reminder_channel, rule_reminder_message = config['rule_reminder_message']
+        bot.rules_message = (await bot.get_channel(rule_reminder_channel).get_message(rule_reminder_message)).content
+        purge_reactions_channel, purge_reactions_message = config['discord_reactions_message']
+        bot.purge_reactions = (await bot.get_channel(purge_reactions_channel).get_message(purge_reactions_message)).content
+    except discord.DiscordException:
+        print("Error retrieving rules and reactions messages")
+        traceback.print_exc()
+        await bot.logout()
+        raise
+    else:
+        print("Ready!")
 
 
 @bot.event
@@ -51,7 +73,7 @@ async def on_message(message):
     if message.author.bot:
         return
     await bot.process_commands(message)
-    if str(message.channel.id) == config['discord_channel_id']:
+    if message.channel.id == config['discord_channel_id']:
         author_info = "{}#{} ({})".format(message.author.name, message.author.discriminator, message.author.id)
         idea = message.clean_content
         trellobot.get_list(config['trello_list_id']).add_card(idea, author_info)
@@ -84,9 +106,7 @@ async def purge(ctx):
     await ctx.send("Purging")
     channel = ctx.guild.get_channel(config['discord_channel_id'])
     print(config['discord_reactions_message'])
-    emoji = (await ctx.get_message(id=int(config['discord_reactions_message']))).content
-    print("Got emoji message as {}".format(emoji))
-    messages = [m async for m in channel.history(limit=None) if any(str(r.emoji) in emoji for r in m.reactions)]
+    messages = [m async for m in channel.history(limit=None) if any(str(r.emoji) in bot.purge_reactions for r in m.reactions)]
     bulk_cutoff = datetime.utcnow() - timedelta(days=14)
     bulk_delete = [m for m in messages if m.created_at >= bulk_cutoff]
     single_delete = [m for m in messages if m.created_at < bulk_cutoff]

--- a/public-ideas-to-trello.py
+++ b/public-ideas-to-trello.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import trello
 import os


### PR DESCRIPTION
The IDs are now an array of [channel_id, message_id], both ints, and are fetched once on startup. The channel ID is also an int for consistency. Requiring explicit channel IDs allows `t!purge` to be run from any channel, not just the one the purge reactions message was sent, and also allows properly fetching the rule reminder message.